### PR TITLE
Add SVG visual motif guard and document visual shape checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,3 +41,10 @@ Recommended workarounds:
   - Make sure your branch is pushed to `origin` first.
   - If the PR still won’t render for others, ask another agent to create the PR from your pushed branch, or (after review) merge via CLI.
 
+
+### Visual motif / shape checks (CSS, SVG, etc.)
+
+- Treat non-textual shapes in CSS/SVG as part of the sabotage surface and review them with the same care as narrative or data content.
+- A style guard in `tests/no-elliptical-border-radius-test.mjs` forbids slash-form `border-radius: ... / ...;` in `styles.css`, `index.html`, and `src/**/*.js` to prevent hard-to-spot elliptical badge shapes from slipping in.
+- An SVG visual motif guard in `tests/svg-visual-motif-guard-test.mjs` currently bans inline `<svg>` elements and `<path d="...">` paths in app/game source unless a future PR adds an explicit allowlist and scoped guard.
+- If you introduce complex custom shapes (CSS or SVG), add a small, focused guard test tied to your module so visual motifs stay intentional and easy to review.

--- a/tests/svg-visual-motif-guard-test.mjs
+++ b/tests/svg-visual-motif-guard-test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+function listTrackedFiles() {
+  const out = execSync('git ls-files', { encoding: 'utf8' });
+  return out.split('\n').map((s) => s.trim()).filter(Boolean);
+}
+
+test('visual motif guard: inline SVG usage requires explicit review/allowlist', () => {
+  const tracked = listTrackedFiles();
+
+  const filesToScan = tracked.filter((f) => {
+    if (f.startsWith('tests/')) return false;
+    if (f.startsWith('docs/')) return false;
+    return f.endsWith('.js') || f.endsWith('.html') || f.endsWith('.css');
+  });
+
+  const svgTagRe = /<svg\b[^>]*>/gi;
+  const pathWithDRe = /<path\b[^>]*\sd="[^"]*"[^>]*>/gi;
+
+  const violations = [];
+
+  for (const file of filesToScan) {
+    const content = fs.readFileSync(file, 'utf8');
+
+    let match;
+    while ((match = svgTagRe.exec(content)) !== null) {
+      const start = Math.max(0, match.index - 80);
+      const end = Math.min(content.length, match.index + match[0].length + 80);
+      violations.push({
+        file,
+        kind: 'svg-tag',
+        snippet: content.slice(start, end),
+      });
+    }
+
+    while ((match = pathWithDRe.exec(content)) !== null) {
+      const start = Math.max(0, match.index - 80);
+      const end = Math.min(content.length, match.index + match[0].length + 80);
+      violations.push({
+        file,
+        kind: 'path-d-attribute',
+        snippet: content.slice(start, end),
+      });
+    }
+  }
+
+  assert.equal(
+    violations.length,
+    0,
+    'visual motif guard: inline SVG <svg> tags and <path d="..."> shapes are currently disallowed in app/game source. ' +
+      'If you intentionally introduce SVG-based shapes, add a scoped guard test and explicit allowlist, then update this guard. ' +
+      '\n\nOffending locations:\n' +
+      violations
+        .map((v) => `- ${v.file} [${v.kind}]\n  …${v.snippet.replace(/\n/g, '\\n')}…`)
+        .join('\n'),
+  );
+});


### PR DESCRIPTION
Adds an SVG-based visual motif guard and documents our visual shape defense strategy for this fork.\n\nChanges:\n- Introduce tests/svg-visual-motif-guard-test.mjs, which scans tracked .js/.html/.css (excluding tests/ and docs/) for inline <svg> tags and <path d="..."> shapes. Any hits fail the test with a clear "visual motif guard" message and instructions to use a scoped allowlist + guard if SVG is intentionally needed.\n- Extend CONTRIBUTING.md with a "Visual motif / shape checks (CSS, SVG, etc.)" section that: (a) treats non-textual shapes as part of the sabotage surface, (b) references the existing no-elliptical-border-radius guard, (c) describes the new SVG guard, and (d) encourages future contributors to add small, module-scoped guards when introducing complex custom shapes.\n\nNotes:\n- This guard is intentionally conservative: it currently blocks *all* inline SVG/path usage in app/game source. If a future UI feature needs SVG, we should relax this test in that PR by adding an explicit allowlist + a more targeted guard test.\n- Verified by running: node --test tests/no-elliptical-border-radius-test.mjs tests/svg-visual-motif-guard-test.mjs.