### PR TITLE
fix: Use displayName for enemy on victory screen

### DIFF
--- a/src/battle-summary.js
+++ b/src/battle-summary.js
@@ -13,7 +13,7 @@ import { computeDerivedStats, formatCombatStatsDisplay } from './combat-stats-tr
 export function createBattleSummary(state) {
   const xpGained = state.xpGained ?? 0;
   const goldGained = state.goldGained ?? 0;
-  const enemyName = state.enemy?.name ?? 'Unknown Enemy';
+  const enemyName = state.enemy?.displayName ?? state.enemy?.name ?? 'Unknown Enemy';
   const lootedItems = Array.isArray(state.lootedItems) ? [...state.lootedItems] : [];
   const levelUps = Array.isArray(state.pendingLevelUps) ? [...state.pendingLevelUps] : [];
 


### PR DESCRIPTION
This pull request fixes the enemy name inconsistency bug on the victory screen. The code now uses the  property of the enemy object, which contains the full, descriptive name, instead of the base  property. This ensures that the correct enemy name is displayed on the victory screen.