### PR TITLE
tests: import-safety for ui-handler + assert state wiring keys

### DIFF
--- a/tests/state-wiring-keys.test.mjs
+++ b/tests/state-wiring-keys.test.mjs
@@ -1,0 +1,35 @@
+import { initialState, initialStateWithClass } from '../src/state.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) {
+    console.log('  PASS: ' + msg);
+    passed++;
+  } else {
+    console.error('  FAIL: ' + msg);
+    failed++;
+  }
+}
+
+console.log('\n--- state wiring keys present ---');
+{
+  const s = initialState();
+  assert('dailyChallengeState' in s, 'initialState has dailyChallengeState');
+  assert('guildSystemState' in s, 'initialState has guildSystemState');
+  assert('encounterState' in s, 'initialState has encounterState');
+  assert('arenaState' in s, 'initialState has arenaState');
+}
+
+console.log('\n--- state wiring keys present (with class) ---');
+{
+  const s = initialStateWithClass('warrior');
+  assert('dailyChallengeState' in s, 'initialStateWithClass has dailyChallengeState');
+  assert('guildSystemState' in s, 'initialStateWithClass has guildSystemState');
+  assert('encounterState' in s, 'initialStateWithClass has encounterState');
+  assert('arenaState' in s, 'initialStateWithClass has arenaState');
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/ui-handler-import-test.mjs
+++ b/tests/ui-handler-import-test.mjs
@@ -1,0 +1,3 @@
+// Ensure src/handlers/ui-handler.js is import-safe in Node (no DOM access at module scope)
+import '../src/handlers/ui-handler.js';
+console.log('ui-handler imported successfully');


### PR DESCRIPTION
- Add Node import-safety test for src/handlers/ui-handler.js (verifies no DOM/window access at module scope)\n- Add state wiring keys test asserting presence of dailyChallengeState, guildSystemState, encounterState, arenaState in both initialState() and initialStateWithClass()\n\nNotes:\n- render.js import-safety is already covered by existing tests (tests/render-import-test.mjs).\n- Pure tests-only change; no runtime code modified.\n- Should help catch regressions from future refactors (import breakage or missing keys).