### PR TITLE
chore(arena): remove dead ARENA_CLAIM_REWARDS handler; consolidate on CLAIM_TOURNAMENT_REWARDS

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -616,22 +616,6 @@ export function handleUIAction(state, action) {
     return pushLog(next, `You enter the ${tournament.name}. Entry fee: ${tournament.entryFee || 0} gold.`);
   }
 
-  if (type === 'ARENA_CLAIM_REWARDS') {
-    const activeId = state.arenaState?.activeTournament;
-    const activeTournament = activeId ? state.arenaState.tournaments?.[activeId] : null;
-    if (!activeTournament || activeTournament.status !== 'completed') return null;
-    const rewards = getTournamentRewards(activeTournament);
-    if (!rewards) return null;
-    const next = {
-      ...state,
-      player: {
-        ...state.player,
-        gold: (state.player.gold || 0) + (rewards.gold || 0)
-      }
-    };
-    return pushLog(next, `Claimed tournament rewards: ${rewards.gold} gold!`);
-  }
-
   if (type === 'RESET_ARENA_SEASON') {
     if (!state.arenaState) return null;
     const arenaState = resetSeason(state.arenaState);


### PR DESCRIPTION
- Remove unused ARENA_CLAIM_REWARDS handler in src/handlers/ui-handler.js\n- Render wiring already uses CLAIM_TOURNAMENT_REWARDS (render.js:2029)\n- Prevents confusion and double-claim drift before human playtests\n\nVerification:\n- Ran CI smoke + accessibility tests locally (both green)\n- Grepped handlers to ensure NEXT_TOURNAMENT_MATCH/FORFEIT_TOURNAMENT/LEAVE_TOURNAMENT remain intact\n\nNo runtime behavior change except removing dead code path.\n\nRefs: DeepSeek-V3.2 note in room chat; PR #15 merged; commits ecc209e, 41ee0f6.