### PR TITLE
feat(fast-travel): gate on visiting at least one other location + clearer copy

### DIFF
--- a/src/fast-travel.js
+++ b/src/fast-travel.js
@@ -139,9 +139,11 @@ export function canUseFastTravel(state) {
     return { canTravel: false, reason: 'Fast travel is only available during exploration.' };
   }
   
+  const currentRoomId = MINIMAP_ROOM_ID_MAP[state.world?.roomRow]?.[state.world?.roomCol];
   const destinations = getUnlockedFastTravelDestinations(state.visitedRooms);
-  if (destinations.length === 0) {
-    return { canTravel: false, reason: 'You have not discovered any locations to travel to.' };
+  const availableDestinations = destinations.filter(destination => destination.id !== currentRoomId);
+  if (availableDestinations.length === 0) {
+    return { canTravel: false, reason: 'Fast Travel unlocks after you visit at least one other location.' };
   }
   
   return { canTravel: true, reason: null };

--- a/tests/fast-travel-test.mjs
+++ b/tests/fast-travel-test.mjs
@@ -265,7 +265,7 @@ describe('Fast Travel System', () => {
       const { canTravel, reason } = canUseFastTravel(state);
       
       assert.equal(canTravel, false);
-      assert.ok(reason.includes('not discovered'));
+      assert.ok(reason.includes('visit at least one other'));
     });
 
     it('should return canTravel false with null visitedRooms', () => {
@@ -273,11 +273,27 @@ describe('Fast Travel System', () => {
       const { canTravel, reason } = canUseFastTravel(state);
       
       assert.equal(canTravel, false);
-      assert.ok(reason.includes('not discovered'));
+      assert.ok(reason.includes('visit at least one other'));
     });
 
-    it('should return canTravel true during exploration with visited rooms', () => {
-      const state = { phase: 'exploration', visitedRooms: ['center'] };
+    it('should return canTravel false during exploration when only current location visited', () => {
+      const state = {
+        phase: 'exploration',
+        visitedRooms: ['center'],
+        world: { roomRow: 1, roomCol: 1 },
+      };
+      const { canTravel, reason } = canUseFastTravel(state);
+      
+      assert.equal(canTravel, false);
+      assert.ok(reason.includes('visit at least one other'));
+    });
+
+    it('should return canTravel true when at least one other location visited', () => {
+      const state = {
+        phase: 'exploration',
+        visitedRooms: ['center', 'e'],
+        world: { roomRow: 1, roomCol: 1 },
+      };
       const { canTravel, reason } = canUseFastTravel(state);
       
       assert.equal(canTravel, true);


### PR DESCRIPTION
Context\n- Players reported confusion when clicking Fast Travel with only the starting room visited; the button sometimes disabled and OPEN_FAST_TRAVEL logged 'no locations' but modal expectation unclear.\n\nChanges\n- canUseFastTravel() now checks for at least one destination other than the current room. If none, returns: 'Fast Travel unlocks after you visit at least one other location.'\n- Keeps exploration-phase guard.\n- No DOM at module scope; remains Node import-safe.\n- Tests updated:\n  * 'only current location visited' -> canTravel false, specific message\n  * 'at least one other location visited' -> canTravel true\n\nWhy\n- Aligns UX with expected behavior (you shouldn't open a destination list that only contains where you already are).\n- Sets clear player expectation for unlock criteria.\n\nQA\n- Unit: tests/fast-travel-test.mjs all pass locally.\n- Keyboard shortcut 'F' still dispatches OPEN_FAST_TRAVEL; handler leverages updated gating to push clear log copy.\n\nFollow-ups\n- Optional: expose requirement in Tutorial/Help.\n- Optional: surface count of discovered locations in tooltip (e.g., 1/9).