### PR TITLE
fix(combat): correct potion heal log amount (no more 0 HP message)

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -429,7 +429,8 @@ export function playerUsePotion(state) {
   }
 
   const heal = items.potion.heal;
-  const hp = clamp(state.player.hp + heal, 0, state.player.maxHp);
+  const beforeHp = state.player.hp;
+  const hp = clamp(beforeHp + heal, 0, state.player.maxHp);
   state = {
     ...state,
     player: {
@@ -440,7 +441,7 @@ export function playerUsePotion(state) {
     },
   };
 
-  state = pushLog(state, `You drink a potion and heal ${hp - (state.player.hp)} HP.`);
+  state = pushLog(state, `You drink a potion and heal ${hp - beforeHp} HP.`);
   if (state.comboState) {
     state = { ...state, comboState: resetCombo(state.comboState) };
   }


### PR DESCRIPTION
The PLAYER_POTION path computed the heal delta after mutating state, so the log always showed 0 HP healed.\n\nChange: compute beforeHp first and log (hp - beforeHp).\n\nNote: Actual healing already worked; this fixes messaging and any consumers reading the inline message. Statistics and defeat screen were unaffected.