### PR TITLE
fix(combat-ui): Fix enemy intent layout straddling columns and label truncation

### DIFF
--- a/src/enemy-intent-ui.js
+++ b/src/enemy-intent-ui.js
@@ -90,9 +90,6 @@ function injectStyles() {
 
     .enemy-intent-label {
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 180px;
     }
 
     .enemy-intent-damage {

--- a/src/render.js
+++ b/src/render.js
@@ -814,7 +814,7 @@ export function render(state, dispatch) {
             <div>Defending</div><div><b>${state.enemy.defending ? 'Yes' : 'No'}</b></div>
             ${renderStatusEffectsRow(state.enemy.statusEffects ?? [])}
             ${state.enemy?.maxShields > 0 ? `<div style="grid-column: 1 / -1">${renderShieldBreakHUD(state.enemy)}</div>` : ''}
-            ${state.intentState ? renderEnemyIntent(state.intentState) : ''}
+            ${state.intentState ? `<div style="grid-column: 1 / -1">${renderEnemyIntent(state.intentState)}</div>` : ''}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Fixes P0 visual bugs from Issue #37 reported by Adam:

### Bug 1: Enemy intent straddling two columns
The enemy intent badge was being placed inside a `.kv` grid (2-column layout) without spanning both columns, causing it to straddle the column boundary awkwardly.

**Fix:** Wrap the intent HTML in a div with `grid-column: 1 / -1` (same pattern used for shield break HUD).

### Bug 2: 'Debuff' label truncated
The `.enemy-intent-label` class had `max-width: 180px` with `text-overflow: ellipsis`, which could truncate intent labels.

**Fix:** Remove the truncation CSS - labels like 'Debuff', 'Heavy Attack' should display fully.

## Testing
- `npm test` passes
- Visual verification needed in browser

Closes part of #37