### PR TITLE
fix(ui): hide empty hud/actions/log panels when unused

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -499,6 +499,16 @@ export function render(state, dispatch) {
   }
 
   const finalizeRender = () => {
+    [hud, actions, log].forEach((panel) => {
+      if (!panel) return;
+      const isEmpty = (panel.innerHTML || '').trim() === '';
+      if (isEmpty) {
+        panel.classList.add('panel-empty');
+      } else {
+        panel.classList.remove('panel-empty');
+      }
+    });
+
     if (state.fastTravelModalOpen) {
       hud.innerHTML += renderFastTravelModal(state);
       attachFastTravelHandlers(dispatch);

--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,10 @@ body {
   padding: 12px;
 }
 
+.panel.panel-empty {
+  display: none;
+}
+
 #actions {
   column-count: 1;
   column-gap: 24px;


### PR DESCRIPTION
Fixes the P0 “random empty box on class/background selection by hiding any main panel that’s truly empty.

- Adds a small helper in `render()`s `finalizeRender()` to mark `#hud`, `#actions`, and `#log` with a `.panel-empty` class whenever their `innerHTML` is empty (after trimming).
- - Adds a CSS rule to hide `.panel.panel-empty` via `display: none`.
- - This keeps panel structure consistent but collapses unused rows so we dont show blank dark bars.
Behavior notes:
- Class selection: the empty `actions` panel is now hidden, so the stray dark bar under the class cards is gone.
- - Background selection (and any other phase that doesnt use one of the three panels) also benefits automatically from the same logic.
- - Any screen that renders content into a panel keeps it visible as before; if content is later cleared, the panel will collapse on the next render.
Testing:
- `npm test` (ci-smoke + accessibility) 
- - `npm run security-scan` ✅
Related:
- Addresses the P0 random empty box on main UI from Adam’s Issue #37 (playtesting notes).