### PR TITLE
fix(ui): add clear tooltip for SPD stat (Issue #37 Item 30)

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -591,7 +591,7 @@ export function render(state, dispatch) {
             <div>HP</div><div><b>${def.baseStats.hp}</b></div>
             <div>ATK</div><div><b>${def.baseStats.atk}</b></div>
             <div>DEF</div><div><b>${def.baseStats.def}</b></div>
-            <div>SPD</div><div><b>${def.baseStats.spd}</b></div>
+            <div title="Speed affects turn order in combat. Higher SPD fills your turn gauge faster, letting you act more frequently.">SPD</div><div><b>${def.baseStats.spd}</b></div>
             <div>INT</div><div><b>${def.baseStats.int}</b></div>
           </div>
           <button data-class="${esc(def.id)}">Choose ${esc(def.name)}</button>
@@ -1637,7 +1637,7 @@ if (state.phase === 'achievements') {
             <div>MP</div><div><b>${player?.mp ?? 0}/${player?.maxMp ?? 0}</b></div>
             <div>ATK</div><div><b>${baseAtk}</b>${eqBonuses.attack ? ` <span style="color:#4f4;">+${eqBonuses.attack}</span> = <b>${effectiveStats.atk}</b>` : ''}</div>
             <div>DEF</div><div><b>${baseDef}</b>${eqBonuses.defense ? ` <span style="color:#4f4;">+${eqBonuses.defense}</span> = <b>${effectiveStats.def}</b>` : ''}</div>
-            <div>SPD</div><div><b>${baseSpd}</b>${eqBonuses.speed ? ` <span style="color:#4f4;">+${eqBonuses.speed}</span> = <b>${effectiveStats.spd}</b>` : ''}</div>
+            <div title="Speed affects turn order in combat. Higher SPD fills your turn gauge faster, letting you act more frequently.">SPD</div><div><b>${baseSpd}</b>${eqBonuses.speed ? ` <span style="color:#4f4;">+${eqBonuses.speed}</span> = <b>${effectiveStats.spd}</b>` : ''}</div>
             <div>Gold</div><div><b>${player?.gold ?? 0}</b></div>
           </div>
         </div>


### PR DESCRIPTION
Addresses **Item 30** from Issue #37 (Adam's playtesting feedback): "unclear to me what SPD does"

## Changes
- Added tooltip to SPD stat label in **character creation screen** (src/render.js line 594)
- Added tooltip to SPD stat label in **inventory screen** (src/render.js line 1640)
- Tooltip text: "Speed affects turn order in combat. Higher SPD fills your turn gauge faster, letting you act more frequently."

## Research
Examined src/combat/combat-engine.js to understand exact SPD mechanics:
- SPD determines turn gauge fill rate (line 157: `c.turnGauge += Math.max(1, Math.floor(c.spd * spdMod))`)
- SPD acts as tiebreaker for turn order when multiple combatants reach 100 gauge (line 163)
- SPD Up/Down status effects multiply speed by 1.5x/0.5x (lines 215-216)

## Testing
- ✅ npm test passes (3948 tests)
- Local browser testing on http://127.0.0.1:8082
- Tooltip uses native HTML title attribute for maximum browser compatibility

Closes #37 (Item 30)